### PR TITLE
Temporary fix for the reloading 404 error

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -6,23 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script>
       (function () {
-        var base = '/menumatch-labeler';
-        var path =
-          window.location.pathname +
-          window.location.search +
-          window.location.hash;
-        if (path.startsWith(base)) {
-          path = path.slice(base.length) || '/';
-        }
-        var redirectUrl =
-          base +
-          '/?redirect=' +
-          encodeURIComponent(path.startsWith('/') ? path : '/' + path);
-        window.location.replace(redirectUrl);
+        // Sends user to the home page
+        window.location.href = window.location.origin; 
       })();
     </script>
   </head>
   <body>
-    <p>Hi, Redirecting…</p>
+    <p>Redirecting…</p>
   </body>
 </html>


### PR DESCRIPTION
Now when the user reloads the website, if they face a 404 error, it automatically reroutes them to the home page.
It also replaces the page they were on with the home page in their history, so they can't go back to that page