### PR TITLE
feat: github links on people page

### DIFF
--- a/src/data/leadership.json
+++ b/src/data/leadership.json
@@ -3,24 +3,28 @@
     "name": "Shium Mashud",
     "role": "Portfolio Manager",
     "headshot": "shium-mashud.jpg",
-    "linkedin": "https://www.linkedin.com/in/shium/"
+    "linkedin": "https://www.linkedin.com/in/shium/",
+    "github": "https://github.com/shiumash"
   },
   {
     "name": "Ethan Carty",
     "role": "Quant Research Lead",
     "headshot": "ethan-carty.jpg",
-    "linkedin": "https://www.linkedin.com/in/ethan-carty/"
+    "linkedin": "https://www.linkedin.com/in/ethan-carty/",
+    "github": "https://github.com/EthanXC"
   },
   {
     "name": "Josef Karpinski",
     "role": "Engineering Lead",
     "headshot": "josef-karpinski.png",
-    "linkedin": "https://www.linkedin.com/in/josefkarpinski/"
+    "linkedin": "https://www.linkedin.com/in/josefkarpinski/",
+    "github": "https://github.com/josef-karpinski"
   },
   {
     "name": "Brendan Barnett",
     "role": "Founder, Advisor",
     "headshot": "brendan-barnett.jpg",
-    "linkedin": "https://www.linkedin.com/in/brendanabarnett/"
+    "linkedin": "https://www.linkedin.com/in/brendanabarnett/",
+    "github": "https://github.com/brendanabarnett"
   }
 ]

--- a/src/data/members.json
+++ b/src/data/members.json
@@ -3,54 +3,63 @@
     "name": "Albert Mundadan",
     "role": "Developer",
     "headshot": "albert-mundadan.png",
-    "linkedin": "https://www.linkedin.com/in/albert-mundadan/"
+    "linkedin": "https://www.linkedin.com/in/albert-mundadan/",
+    "github": "https://github.com/AlbertMundadan"
   },
   {
     "name": "Emmet Spaeth",
     "role": "Researcher",
     "headshot": "emmet-spaeth.png",
-    "linkedin": "https://www.linkedin.com/in/emmet-spaeth-136165309/"
+    "linkedin": "https://www.linkedin.com/in/emmet-spaeth-136165309/",
+    "github": "https://github.com/mineable3"
   },
   {
     "name": "Ethan Thomas",
     "role": "Developer",
     "headshot": "ethan-thomas.png",
-    "linkedin": "https://www.linkedin.com/in/ethanthomas0/"
+    "linkedin": "https://www.linkedin.com/in/ethanthomas0/",
+    "github": "https://github.com/ethant0123"
   },
   {
     "name": "Grace McPadden",
     "role": "Researcher",
     "headshot": "grace-mcpadden.png",
-    "linkedin": "https://www.linkedin.com/in/grace-mcpadden/"
+    "linkedin": "https://www.linkedin.com/in/grace-mcpadden/",
+    "github": "https://github.com/GraceMcPadden2"
   },
   {
     "name": "Katrina Melnik",
     "role": "Researcher",
     "headshot": "katrina-melnik.jpg",
-    "linkedin": "https://www.linkedin.com/in/katrina-melnik-b4b559241/"
+    "linkedin": "https://www.linkedin.com/in/katrina-melnik-b4b559241/",
+    "github": "https://github.com/katmlnk"
   },
   {
     "name": "Micah Banschick",
     "role": "Researcher",
     "headshot": "micah-banschick.png",
-    "linkedin": "https://www.linkedin.com/in/micah-banschick/"
+    "linkedin": "https://www.linkedin.com/in/micah-banschick/",
+    "github": "https://github.com/micahabanschick"
   },
   {
     "name": "Parth Danve",
     "role": "Researcher",
     "headshot": "parth-danve.jpg",
-    "linkedin": "https://www.linkedin.com/in/parthdanve39/"
+    "linkedin": "https://www.linkedin.com/in/parthdanve39/",
+    "github": "https://github.com/pdd23001"
   },
   {
     "name": "Shawn Spitzel",
     "role": "Developer",
     "headshot": "shawn-spitzel.jpg",
-    "linkedin": "https://www.linkedin.com/in/shawn-spitzel-b16b47298/"
+    "linkedin": "https://www.linkedin.com/in/shawn-spitzel-b16b47298/",
+    "github": "https://github.com/shawnspitzel"
   },
   {
     "name": "Soonwoo Kwon",
     "role": "Developer",
     "headshot": "soonwoo-kwon.png",
-    "linkedin": "https://www.linkedin.com/in/soonwook/"
+    "linkedin": "https://www.linkedin.com/in/soonwook/",
+    "github": "https://github.com/swoonyk"
   }
 ]

--- a/src/pages/Team.jsx
+++ b/src/pages/Team.jsx
@@ -23,6 +23,23 @@ const resolveHeadshot = (filename) => {
   return match ? match[1] : null;
 };
 
+const LinkedInIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M4.98 3.5C4.98 4.88 3.86 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM0 8.5h5V24H0V8.5zM8.5 8.5h4.8v2.11h.07c.67-1.27 2.32-2.61 4.77-2.61 5.1 0 6.04 3.36 6.04 7.73V24h-5v-7.08c0-1.69-.03-3.87-2.36-3.87-2.36 0-2.72 1.85-2.72 3.75V24h-5V8.5z" />
+  </svg>
+);
+
+const GitHubIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M12 0C5.37 0 0 5.5 0 12.29c0 5.43 3.44 10.03 8.2 11.66.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.75-4.04-1.67-4.04-1.67-.55-1.42-1.34-1.8-1.34-1.8-1.09-.77.08-.76.08-.76 1.2.09 1.83 1.27 1.83 1.27 1.07 1.88 2.8 1.34 3.49 1.02.11-.8.42-1.34.76-1.65-2.67-.31-5.47-1.38-5.47-6.14 0-1.36.47-2.47 1.24-3.35-.12-.31-.54-1.58.12-3.3 0 0 1.01-.33 3.3 1.28a11.2 11.2 0 0 1 6 0c2.29-1.61 3.3-1.28 3.3-1.28.66 1.72.24 2.99.12 3.3.77.88 1.23 1.99 1.23 3.35 0 4.78-2.8 5.82-5.48 6.13.43.38.82 1.12.82 2.26 0 1.63-.02 2.95-.02 3.35 0 .32.22.7.83.58 4.76-1.63 8.2-6.23 8.2-11.66C24 5.5 18.63 0 12 0z" />
+  </svg>
+);
+
+const buildSocialLinks = (member) => ([
+  { href: member.linkedin, label: 'LinkedIn', Icon: LinkedInIcon },
+  { href: member.github, label: 'GitHub', Icon: GitHubIcon },
+].filter((link) => link.href));
+
 function Team() {
   return (
     <div className="team">
@@ -37,20 +54,12 @@ function Team() {
           <div className="team-grid">
             {leadership.map((member, idx) => {
               const headshotSrc = resolveHeadshot(member.headshot);
-              const Wrapper = member.linkedin ? 'a' : 'div';
-              const wrapperProps = member.linkedin
-                ? {
-                    href: member.linkedin,
-                    target: '_blank',
-                    rel: 'noreferrer',
-                  }
-                : {};
+              const socialLinks = buildSocialLinks(member);
 
               return (
-                <Wrapper
+                <div
                   key={idx}
-                  className={`team-card${member.linkedin ? ' team-card-link' : ''}`}
-                  {...wrapperProps}
+                  className="team-card"
                 >
                   <div className="team-avatar">
                     {headshotSrc && <img src={headshotSrc} alt={member.name} />}
@@ -58,7 +67,24 @@ function Team() {
                   <h3>{member.name}</h3>
                   <p className="role">{member.role}</p>
                   {member.bio && <p className="bio">{member.bio}</p>}
-                </Wrapper>
+                  {socialLinks.length > 0 && (
+                    <div className="team-card-links">
+                      {socialLinks.map(({ href, label, Icon }) => (
+                        <a
+                          key={label}
+                          className="team-card-link"
+                          href={href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`${member.name} on ${label}`}
+                          title={label}
+                        >
+                          <Icon />
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
               );
             })}
           </div>
@@ -69,27 +95,36 @@ function Team() {
           <div className="team-grid">
             {members.map((member, idx) => {
               const headshotSrc = resolveHeadshot(member.headshot);
-              const Wrapper = member.linkedin ? 'a' : 'div';
-              const wrapperProps = member.linkedin
-                ? {
-                    href: member.linkedin,
-                    target: '_blank',
-                    rel: 'noreferrer',
-                  }
-                : {};
+              const socialLinks = buildSocialLinks(member);
 
               return (
-                <Wrapper
+                <div
                   key={idx}
-                  className={`team-card${member.linkedin ? ' team-card-link' : ''}`}
-                  {...wrapperProps}
+                  className="team-card"
                 >
                   <div className="team-avatar">
                     {headshotSrc && <img src={headshotSrc} alt={member.name} />}
                   </div>
                   <h3>{member.name}</h3>
                   <p className="role">{member.role}</p>
-                </Wrapper>
+                  {socialLinks.length > 0 && (
+                    <div className="team-card-links">
+                      {socialLinks.map(({ href, label, Icon }) => (
+                        <a
+                          key={label}
+                          className="team-card-link"
+                          href={href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`${member.name} on ${label}`}
+                          title={label}
+                        >
+                          <Icon />
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
               );
             })}
           </div>

--- a/src/styles/Team.css
+++ b/src/styles/Team.css
@@ -64,12 +64,6 @@
   transition: all 0.3s ease;
 }
 
-.team-card-link {
-  display: block;
-  text-decoration: none;
-  color: inherit;
-}
-
 .team-card:hover {
   transform: translateY(-6px);
   background: var(--color-surface-elevated);
@@ -111,6 +105,39 @@
   font-size: 0.9rem;
   color: var(--color-muted);
   line-height: 1.5;
+}
+
+.team-card-links {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.team-card-link {
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  text-decoration: none;
+}
+
+.team-card-link svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.team-card-link:hover {
+  color: var(--color-text);
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-2px);
 }
 
 .alumni-list {


### PR DESCRIPTION
We love AI-generated frontend slop.

- Added functionality for links to github profiles for each member on the team page
- Removed the functionality of clicking on a person's card sending to their linkedin
- Added LinkedIn and GitHub icons on the person card to link to respective pages